### PR TITLE
chore(lsp): remove redundant code

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -42,7 +42,6 @@ vim.cmd.colorscheme("habamax")
 vim.diagnostic.config({ virtual_text = { current_line = true } })
 vim.lsp.config("*", {
     root_markers = { ".git" },
-    capabilities = require("blink.cmp").get_lsp_capabilities(),
 })
 
 require("mason").setup()


### PR DESCRIPTION
Blink sets this by default, see [plugin/blink-cmp](https://github.com/Saghen/blink.cmp/blob/main/plugin/blink-cmp.lua)